### PR TITLE
Update to use generic api urls

### DIFF
--- a/src/public/apps/bb/app.js
+++ b/src/public/apps/bb/app.js
@@ -11,10 +11,13 @@
         isIE: /msie/i.test(navigator.userAgent) && !window.opera, //easy way to determine if ie
         isLowerIE8: (document.all && !document.querySelector) ? true: false,  //ie less than ie 8
         dispatcher: dispatcher,
-        //local developer laptop
-        //eddaBaseUrl: 'http://localhost:8080/edda/api/v2/'
-        //demo server
-        eddaBaseUrl: 'http://sentia.demo.cfpb.gov/eddahome/edda/api/v2/'
+        api:
+        {
+            instancesUrl: '/api/instances/?filter={"providers": ["aws"] }',
+            availabilityZonesUrl: '/api/availabilityzones/?filter={"providers": ["aws"] }',
+            vpcsUrl:'/api/vpcs/?filter={"providers": ["aws"] }',
+            subnetsUrl:'/api/subnets/?filter={"providers": ["aws"] }'
+        }
     };
 
     //localize or create a new Javascript Template Object

--- a/src/public/apps/bb/components/networkchart/networkChartApp.js
+++ b/src/public/apps/bb/components/networkchart/networkChartApp.js
@@ -23,7 +23,8 @@ define(["app", "backbone", "d3", "components/networkchart/views/networkChartView
 
          //calculate # of regions  , fetch is async , so wait until done then
          //create regionCollection base on querying aws.availabilityZones
-         availabilityZoneList.url = app.eddaBaseUrl + "aws/availabilityzones;_pp;_meta;";
+         //generic api
+         availabilityZoneList.url = app.api.availabilityZonesUrl;
          $.when(availabilityZoneList.fetch({
                  type: "GET",
                  cache: true,
@@ -45,7 +46,8 @@ define(["app", "backbone", "d3", "components/networkchart/views/networkChartView
                  });
 
                  //Get Instances
-                 instanceList.url = app.eddaBaseUrl + "view/instances;_pp;_meta;";
+                 //generic api
+                 instanceList.url = app.api.instancesUrl;
                  $.when(instanceList.fetch({
                          type: "GET",
                          cache: true,
@@ -89,8 +91,8 @@ define(["app", "backbone", "d3", "components/networkchart/views/networkChartView
                              region.set("vpcCollection",vpcsInRegion);
                              region.set("numberOfInstances",numberOfInstancesInRegion);
                          });
-
-                        vpcList.url = app.eddaBaseUrl + "aws/vpcs;_pp;_meta;";
+                        //generic api
+                         vpcList.url = app.api.vpcsUrl;
                          $.when(vpcList.fetch({
                                  type: "GET",
                                  cache: true,
@@ -128,8 +130,8 @@ define(["app", "backbone", "d3", "components/networkchart/views/networkChartView
                                });
 
                              });
-
-                         subnetList.url = app.eddaBaseUrl + "aws/subnets;_pp;_meta;";
+                         //generic api
+                         subnetList.url = app.api.subnetsUrl;
                          $.when(subnetList.fetch({
                                  type: "GET",
                                  cache: true,

--- a/src/public/apps/bb/components/networkchart/networkChartNonVpcsApp.js
+++ b/src/public/apps/bb/components/networkchart/networkChartNonVpcsApp.js
@@ -23,7 +23,7 @@ define(["app", "backbone", "d3", "components/networkchart/views/networkChartNonV
 
             //calculate # of regions  , fetch is async , so wait until done then
             //create regionCollection base on querying aws.availabilityZones
-            availabilityZoneList.url = app.eddaBaseUrl + "/aws/availabilityzones;_pp;_meta;";
+            availabilityZoneList.url = app.api.availabilityZonesUrl;
             $.when(availabilityZoneList.fetch({
                 type: "GET",
                 cache: true,
@@ -45,7 +45,7 @@ define(["app", "backbone", "d3", "components/networkchart/views/networkChartNonV
                 });
 
                 //Get Instances
-                instanceList.url = app.eddaBaseUrl + "view/instances;_pp;_meta;";
+                instanceList.url = app.api.instancesUrl;
                 $.when(instanceList.fetch({
                     type: "GET",
                     cache: true,
@@ -83,7 +83,7 @@ define(["app", "backbone", "d3", "components/networkchart/views/networkChartNonV
 
 
 
-                    subnetList.url = app.eddaBaseUrl + "aws/subnets;_pp;_meta;";
+                    subnetList.url = app.api.subnetsUrl;
                     $.when(subnetList.fetch({
                         type: "GET",
                         cache: true,

--- a/test/server/server_spec.js
+++ b/test/server/server_spec.js
@@ -63,6 +63,7 @@ describe('Server', function(){
     });
 
     describe('Get instances via api/instances/ from all providers', function() {
+        this.timeout(60000); //increase default time to 1 minute, due potentially large number of instances
         it('should respond to GET', function(done){
             sentiaInfoRequest
                 .get('/api/instances/')


### PR DESCRIPTION
 Use generic api urls rather than edda specific url.
 Having generic api endpoints allows for more easily adding
 other cloud providers beyond aws.
